### PR TITLE
Group Addition (usa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ___
 
-![DCG Groups](https://github.com/DefconParrot/DefconGroups/assets/30528167/dfa8b731-b14c-440b-82dd-2fa560737f10)
+![latest DCG Groups](https://github.com/DefconParrot/DefconGroups/assets/30528167/adc58358-4c96-4288-af1d-79ceaa94378e)
 
 ___
 
@@ -26,6 +26,8 @@ pending...
 ## Stats:
 Total Defcon Groups(2023): Pending
 
+<a name="top"></a>
+
 ## DEF CON Groups USA
 
 | ID | DCG Name           | Group Location | Website           |  Social Link / Point of Contact                |              Join Group      |
@@ -47,26 +49,55 @@ Total Defcon Groups(2023): Pending
 |15 | DC254  | Killeen, Texas USA | www.dc254.com | POC: DC254 </br> - [Email Group↗](mailto:DefCon254@gmail.com) </br> - [Twitter](https://twitter.com/_dc254_) | [Sign in to join](https://forum.defcon.org/node/231686) |
 |16 | DC408   | San Jose, California USA | www.dc408.com | POC: The Infamous Kevin </br> - [Email Group↗](mailto:TheInfamousKevin@dc408.com) </br> - [Twitter↗](https://twitter.com/_dc408) | [Sign in to join](https://forum.defcon.org/node/231128) |
 |17 | DC541   | Eugene, Oregon USA | N/A | POC: Maren </br> - [Email Group↗](mailto:defcon541@gmail.com) | [Sign in to join](https://forum.defcon.org/node/231682) |
-|18 | DCG940  | Denton, Texas | dc940.org | POC: Rick, Sheldon & Darin </br> //pending email </br> - [Twitter↗](https://twitter.com/DCG940) | [Sign in to join](https://forum.defcon.org/node/239814) |
+|18 | DCG940  | Denton, Texas | www.dc940.org | POC: Rick, Sheldon & Darin </br> - [Twitter↗](https://twitter.com/DCG940) | [Sign in to join](https://forum.defcon.org/node/239814) |
 |19 | DC713   | Houston, Texas USA | www.dc713.net | POC: djdead </br> [Email Group↗](mailto:dead@twistofshadows.net) </br> [Twitter↗](https://twitter.com/dc713hou) | [Sign in to join](https://forum.defcon.org/node/231687) |
 |20 | DC305   | Miami, Florida USA | N/A | POC: Richard Chance </br> - [Email Group↗](mailto:primary@dc305.com) | [Sign in to join](https://forum.defcon.org/node/231651) |
 |21 | DC239   | Bonita Springs, Florida USA | www.swflsec.com | POC: Mike </br> - [Email Group↗](mailto:SWFLSec@protonmail.com) </br> - [Twitter↗](https://twitter.com/DCGroup239) | [Sign in to join](https://forum.defcon.org/node/231650) | 
 |22 | DC321  | Satellite Beach, Florida USA | www.dc321.org | POC: C2 </br> - [Email Group↗](mailto:C2@dc321.org) | [Sign in to join](https://forum.defcon.org/node/231652) | 
 |23 | DC858  | San Diego, California USA | www.dc858.org | POC: 800xl </br> - [Email Group↗](mailto:800xl@dc858.org) </br> - [Twitter↗](https://twitter.com/DCG858) | [Sign in to join](https://forum.defcon.org/node/231445) | 
+|24 | DC414  | Franklin, Wisconsin USA | www.dc414.org | POC: Crew </br> - [Email Group↗](mailto:800xl@dc858.org) </br> - [Twitter↗](https://twitter.com/dc414) </br> - [Discord↗](https://discord.gg/DrtEyNbG7u) </br> - [Upcoming meet ups↗](https://www.meetup.com/dc414group/)| [Sign in to join](https://forum.defcon.org/node/231696) |
+|25 | DC907  | Anchorage, Alaska USA | N/A | POC: Steve Sedotto </br> - [Email Group↗](mailto:defcon907@gmail.com) </br> - [Twitter↗](https://twitter.com/DC_907) | [Sign in to join](https://forum.defcon.org/node/231637) |  
+|26 | DC937  | Dayton, Ohio USA | N/A | POC: Nicole Beckwith & Clayton Horstman </br> - [Email Group↗](mailto:nicolebeckwith@protonmail.com) | [Sign in to join](https://forum.defcon.org/node/231679) | 
+|27 | DC501    | Little Rock, Arkansas, USA | www.dc501.org | POC: Dylan Hailey </br> - [Email Group↗](mailto:dc501@dylanhailey.com) </br> - [Twitter↗](https://twitter.com/DC501org) | [Sign in to join](https://forum.defcon.org/node/231638) | 
+|28 | DCG320  | St. Cloud, Minnesota | n/a | POC: Blake Thoennes </br> - [Email Group↗](mailto:blake.thoennes@gmail.com) | [Sign in to join](https://forum.defcon.org/node/241277)| 
+|29 | DC253   | Tacoma, Washington USA | www.dc253.org | POC: 3mu|0r </br> - [Email Group↗](mailto:dc253@protonmail.org) </br> - [Discord↗](https://discord.gg/6QcHJXa) | [Sign in to join](https://forum.defcon.org/node/231692) | 
+|30 | DC207 | Portland, Maine USA | [dc207.org](http://events.dc207.org) | POC: Virginia Ham </br> - [Email Group↗](mailto:root@dc207.org) </br> - [Twitter↗](https://twitter.com/dcg207) </br> - [Discord↗](https://discord.com/invite/JjpKF6sFW6) | [Sign in to join](https://forum.defcon.org/node/231667) | 
+|31 | DC502  | Louisville, Kentucky USA | www.dc502.org | POC: The_Gibson </br> - [Email Group↗](mailto:thegibson@hackers.town) </br> - [Twitter↗](https://twitter.com/defcon502)  | [Sign in to join](https://forum.defcon.org/node/231666) |
+| 32 | DC902 | Halifax, Canada | www.dc902.ca | POC: Jeff Hann </br> - [Email Group↗](mailto:jhann@protomail.com) </br> - [Twitter↗](https://twitter.com/DefCon902) </br> - [Discord↗](https://discord.gg/wbPXa9B) | [Sign in to join](https://forum.defcon.org/node/231548) |
+| 33 | DC360  | Mount Vernon, Washington USA |N/A | POC: d0c </br> - [Email Group↗](mailto:Grep.d0c@gmail.com) | [Sign in to join](https://forum.defcon.org/node/231693) |
+| 34 | DC864  | Greenville, South Carolina USA | www.dc864.org | POC: Ben Acord & Eric Hart </br> - [Email Group↗](mailto:DefCon864info@gmail.com) </br> - [Twitter↗](http://twitter.com/DEFCON864/) </br> - [Discord↗](https://discord.gg/yc2xVAxwUc) | [Sign in to join](https://forum.defcon.org/node/231482) | 
+| 35 | DC865   | Knoxville, Tennessee USA | www.dc865.org | POC:Zacht </br> - [Email Group↗](mailto:nvemb3r@dc865.org) </br> - [Backup Email↗](mailto:c_3pjoe@c865.org) </br> - [Twitter↗](https://twitter.com/defcon865) </br>[Upcoming events↗](https://dc865.eventbrite.com/) | [Sign in to join](https://forum.defcon.org/node/231485) | 
+| 36 | DCG504  | New Orleans and North Shore, Louisiana | N/A | POC: T., NotJanice, and Malate </br> - [Twitter↗](https://twitter.com/dcg504) | [Sign in to join](https://forum.defcon.org/node/241288) |
+| 37 | DC626   | Pasadena, California USA | N/A | POC: Exist </br> - [Email Group↗](mailto:exist@ymail.com) </br>[Upcoming events↗](https://dc865.eventbrite.com/) | [Sign in to join](https://forum.defcon.org/node/231641) | 
+| 38 | DC217   | Urbana, Illinois USA | www.dc217.org | POC: saint </br> - [Email Group↗](mailto:info@dc217.com) </br> - [Twitter↗](https://twitter.com/DCCU217) | [Sign in to join](https://forum.defcon.org/node/231663) |
+| 39 | DC539  | Tulsa, Oklahoma USA | www.dc539.org | POC: thinc </br> - [Email Group↗](mailto:defcon539@gmail.com) </br> - [Backup Email](mailto:dc539@gmail.com) </br> - [Twitter↗](https://twitter.com/defcon539) </br> - [Discord↗](https://discord.gg/QpTv7PD)| [Sign in to join](https://forum.defcon.org/node/231466) |
+| 40 | DC602  | North Phoenix, Arizona USA | www.dc602.com | POC: Sark Dumont </br> - [Email Group↗](mailto:SarkDumont@gmail.com) </br> - [Backup Email↗](mailto:rekognizer@gmail.com) </br> - [Twitter↗](https://twitter.com/dc602) | [Sign in to join](https://forum.defcon.org/node/231440) |
+| 41 | DC201  | Hoboken, New Jersey USA | www.defcon201.org | POC: sidepocket </br> - [Email Group↗](mailto:info@defcon201.org) | [Sign in to join](https://forum.defcon.org/node/231132) |
+| 42 | DC614  | Columbus, Ohio USA | www.dc614.org | POC: Princess, Phorkus, SteveU & hashgrind </br> - [Reach out to POC (x)↗](https://twitter.com/princess_htw) </br> - [Group Twitter Acc↗](https://twitter.com/dcg614) </br> - [Reddit↗](https://www.reddit.com/r/DC614/) | [Sign in to join](https://forum.defcon.org/node/231465) |
 
+
+[Back to Top](#top)
 
 ## DEF CON Groups International 
 
 | ID | DCG Name           | Group Location | Website        |  Social Link/ Point of Contact | Join Group    |
 |----|--------------------|----------------|----------------|--------------------------------|---------------|
-| 1  | | | | | | 
+| 1 | DCG441905 | Worcester, United Kingdom | dc441905.org | POC: dc441905 </br> - [Email Group↗](mailto:info@dc441905.org) </br> - [Twitter↗](https://twitter.com/dc441905) </br> - [YouTube↗](https://www.youtube.com/channel/UCufwYsSoIlyhc8B0JkqC4uA)  | [Sign in to join](https://forum.defcon.org/node/235011) |
+| 2 | DC78412  | Penza, Russian Federation | [dc501.org](http://defcon58.ru/) | POC: Ivan Kulkov </br> - [Email Group↗](mailto:poc@defcon58.ru) | [Sign in to join](https://forum.defcon.org/node/231522) |
+| 3 | DC3491  | Madrid, Spain | n/a | POC: Claudio </br> - [Email Group↗](mailtoclaudio.chn@gmail.com) </br> - [Twitter↗](https://twitter.com/DC3491) | [Sign in to join](https://forum.defcon.org/node/231611) |
+| 4 | DC514  | Montreal, Quebec, Ontario, Canada | www.dcg514.ca | POC: B34v3r </br> - [Email Group↗](mailto:b34v3r@dcg514.ca)| [Sign in to join](https://forum.defcon.org/node/231543) | 
+| 5 | DC11332  | Rennes - Ille et Vilaine, France | www.dc11332.org | POC: Yann </br> - [Email Group↗](mailto:yann@dc11332.org) </br> - [Twitter↗](https://twitter.com/dc11332) | [Sign in to join](https://forum.defcon.org/node/236272) | 
+| 6 | DCG40264 | Cluj, Romania | N/A | N/A | [Sign in to join](https://forum.defcon.org/node/243782) | 
+| 7 | DCG994 | Baku, Azerbaijan | N/A | POC: N/A </br> - [Email Group↗](mailto:dc994@dnmx.org) </br> - [Telegram↗](https://t.me/DCG994) | [Sign in to join](https://forum.defcon.org/node/232928) |
+| 8 | DCG441382 | Dundee, Scotland | N/A | POC: Casual_Unknown, @TheHairyJ, & Mark Brenmer  </br> - [Twitter↗](https://twitter.com/DC441382) | [Sign in to join](https://forum.defcon.org/node/241271) |
+
 
 
 ## DEF CON Groups China 
 
 | ID | DCG Name           | Group Location | Website        |  Social Link/ Point of Contact | Join Group    |
 |----|--------------------|----------------|----------------|--------------------------------|---------------|
-| 1  | | | | | | 
+| 1 | DC86020 |Tianhe District, Guangzhou, China | www.dc86020.ngsst.com | POC: akast </br> - [Email Group↗](mailto:akast@ngsst.com) </br> - [Backup Email↗](mailto:sec@hillstonenet.com) | [Sign in to join](https://forum.defcon.org/node/231555) |
 
 
 ## Uncategorized Groups


### PR DESCRIPTION
- Addition of USA groups before moving over to other categories. Groups added on the International section were added to the USA group by mistake and I had to move them to the proper category rather than deleting them. 